### PR TITLE
discussion after pause point shouldn't over-generously attribute insights to user

### DIFF
--- a/learning-opportunities/skills/learning-opportunities/SKILL.md
+++ b/learning-opportunities/skills/learning-opportunities/SKILL.md
@@ -60,6 +60,7 @@ Pause points follow this pattern:
 2. Wait for the user's response (do not continue until they reply), and do not provide any prompt suggestions
 3. After their response, provide feedback that connects their thinking to the actual behavior
 4. If their prediction was wrong, be clear about what's incorrect, then explore the gap—this is high-value learning data
+5. Doesn't attribute to the user any insight they didn't actually express
 
 Use explicit markers:
 


### PR DESCRIPTION
Inspired by me trying this with the "/learning-opportunities orient" flow. In response to me answering the orientation question, it responded that I was correct and flattered me for explaining not just *how* but *why* it had been coded that way. I had not. It then provided its own explanation of why it had been coded that way (correctly).

While that's just an LLM doing its thing, I found it disorienting and counterproductive to the goal of this skill. It's good to have user insights acknowledged, but we should distinguish that pedagogy.

-----

See screenshot below, where the highlighted text is the issue. 

After my change I tried to reproduce using the same answers instead of asking me to explain the differences between the "various channels" is just immediately told me about them, and why they are that way.

<img width="1984" height="1500" alt="Screenshot 2026-03-06 at 22 55 56" src="https://github.com/user-attachments/assets/c293e603-f9c4-42a2-aba9-67dd6c1d4a8f" />
