### PR TITLE
learning-opportunities-auto: make post-commit nudge more robust

### DIFF
--- a/learning-opportunities-auto/hooks/post-tool-use.sh
+++ b/learning-opportunities-auto/hooks/post-tool-use.sh
@@ -37,11 +37,50 @@ if [[ -z "$SESSION_ID" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Session state: track how many exercises have been offered this session.
-# Uses a temp file keyed on session ID; resets when the session ends.
+# Extract cwd so we can query git in the repo the commit was made in,
+# and identify the commit by its short SHA for de-duplication below.
 # ---------------------------------------------------------------------------
 
-STATE_FILE="${TMPDIR:-/tmp}/lo_auto_${SESSION_ID//[^a-zA-Z0-9_-]/_}.state"
+CWD=$(echo "$INPUT" | grep -o '"cwd":"[^"]*"' | head -1 | sed 's/"cwd":"//;s/"$//')
+if [[ -z "$CWD" ]]; then
+  CWD="$PWD"
+fi
+
+SHA=$(git -C "$CWD" rev-parse --short HEAD 2>/dev/null) || exit 0
+if [[ -z "$SHA" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Verify the commit actually landed. If HEAD's commit timestamp isn't
+# very recent, the `git commit` call likely failed (e.g. pre-commit hook
+# rejected it) and HEAD is still the *previous* commit — in which case
+# we'd nudge about stale work. Skip silently in that case.
+# ---------------------------------------------------------------------------
+
+COMMIT_TS=$(git -C "$CWD" log -1 --format=%ct 2>/dev/null) || exit 0
+NOW=$(date +%s)
+if (( NOW - COMMIT_TS > 30 )); then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Session state:
+#   * .state  — count of emitted offers this session (cap at 2)
+#   * .seen   — commit SHAs we've already nudged about (de-dupe)
+# Both live in $TMPDIR keyed on session id; reset when the session ends.
+# The counter increments only when a nudge is actually emitted, and the
+# per-SHA de-dupe ensures a single commit can't consume multiple offers
+# from the session cap if this hook is invoked more than once for it.
+# ---------------------------------------------------------------------------
+
+SAFE_ID="${SESSION_ID//[^a-zA-Z0-9_-]/_}"
+STATE_FILE="${TMPDIR:-/tmp}/lo_auto_${SAFE_ID}.state"
+SEEN_FILE="${TMPDIR:-/tmp}/lo_auto_${SAFE_ID}.seen"
+
+if [[ -f "$SEEN_FILE" ]] && grep -q "^${SHA}$" "$SEEN_FILE" 2>/dev/null; then
+  exit 0
+fi
 
 offers=0
 if [[ -f "$STATE_FILE" ]]; then
@@ -53,17 +92,26 @@ if [[ "$offers" -ge 2 ]]; then
   exit 0
 fi
 
-# Record the offer.
+# ---------------------------------------------------------------------------
+# Grab the commit subject so the nudge can mention a concrete topic.
+# Sanitize to stay safely embeddable in the JSON string below: strip
+# newlines, tabs, carriage returns, double-quotes, and backslashes, and
+# cap length.
+# ---------------------------------------------------------------------------
+
+SUBJECT=$(git -C "$CWD" log -1 --pretty=%s 2>/dev/null | head -c 160 | tr -d '"\r\n\t\\')
+
+# Record that we're emitting a nudge for this commit, then emit.
+echo "$SHA" >> "$SEEN_FILE"
 echo $(( offers + 1 )) > "$STATE_FILE"
 
 # ---------------------------------------------------------------------------
 # Emit suggestion for Claude via structured JSON. PostToolUse hooks must
 # output JSON with hookSpecificOutput on exit 0 to inject context.
-# The message contains no special characters that need escaping.
 # ---------------------------------------------------------------------------
 
-cat <<'HOOK_JSON'
-{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"[learning-opportunities-auto] The user just committed code. Per the learning-opportunities skill, consider whether this is a good moment to offer a learning exercise. If the committed work involved new files, schema changes, architectural decisions, refactors, or unfamiliar patterns, ask the user (one short sentence) if they'd like a 10-15 minute exercise. Do not start the exercise until they confirm. If they decline, note it — no more offers this session."}}
+cat <<HOOK_JSON
+{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"[learning-opportunities-auto] The user just committed code (${SHA}: ${SUBJECT}). Per the learning-opportunities skill, consider whether this is a good moment to offer a learning exercise. If the committed work involved new files, schema changes, architectural decisions, refactors, or unfamiliar patterns, ask the user (one short sentence) if they'd like a 10-15 minute exercise. Do not start the exercise until they confirm. If they decline, note it — no more offers this session."}}
 HOOK_JSON
 
 exit 0


### PR DESCRIPTION
Three small changes to `post-tool-use.sh`. Trigger gate and nudge phrasing unchanged.

- **Fix counter.** `offers` previously bumped on every hook fire, burning the 2/session cap even when no nudge landed. Now increments only on emit, de-duped per commit SHA.
- **Guard failed commits.** If `git commit` was rejected, HEAD is the previous commit. Skip silently unless HEAD's timestamp is within ~30s.
- **Add commit context.** Nudge prefixes `(${SHA}: ${SUBJECT})` so the skill has a concrete topic. Subject sanitized + truncated for safe JSON embedding.

No new dependencies.

Happy to split into three commits if you'd prefer cherry-pickability.