### PR TITLE
Add OpenCode and GitHub Copilot CLI support

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "learning-opportunities",
   "owner": {
     "name": "Dr. Cat Hicks",
@@ -11,19 +10,6 @@
   },
   "plugins": [
     {
-      "name": "learning-opportunities-auto",
-      "source": "./learning-opportunities-auto",
-      "description": "Automatically nudges the agent to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
-      "version": "1.1.0",
-      "author": {
-        "name": "Dr. Cat Hicks",
-        "email": "dr.cat.hicks@gmail.com"
-      },
-      "license": "CC-BY-4.0",
-      "keywords": ["learning", "education", "skill-development", "expertise", "learning-science", "hooks"],
-      "category": "education"
-    },
-    {
       "name": "learning-opportunities",
       "source": "./learning-opportunities",
       "description": "Science-based learning exercises for deliberate skill development during AI-assisted coding",
@@ -34,6 +20,19 @@
       },
       "license": "CC-BY-4.0",
       "keywords": ["learning", "education", "skill-development", "expertise", "learning-science"],
+      "category": "education"
+    },
+    {
+      "name": "learning-opportunities-auto",
+      "source": "./learning-opportunities-auto",
+      "description": "Automatically nudges the agent to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
+      "version": "1.1.0",
+      "author": {
+        "name": "Dr. Cat Hicks",
+        "email": "dr.cat.hicks@gmail.com"
+      },
+      "license": "CC-BY-4.0",
+      "keywords": ["learning", "education", "skill-development", "expertise", "learning-science", "hooks"],
       "category": "education"
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## learning-opportunities 1.1.0
+
+Added GitHub Copilot CLI and OpenCode support.
+
+**New:**
+- `.github/plugin/marketplace.json` for canonical Copilot CLI marketplace discovery
+- `skills` field in `.claude-plugin/plugin.json` for explicit skill path declaration (Copilot CLI)
+
+## learning-opportunities-auto 1.1.0
+
+Added GitHub Copilot CLI and OpenCode support.
+
+**New:**
+- `.opencode/plugins/learning-opportunities-auto.ts` — OpenCode event plugin equivalent of the bash hook
+- `hooks` field in `.claude-plugin/plugin.json` for explicit hook path declaration (Copilot CLI)
+
+## orient 1.1.0
+
+Added GitHub Copilot CLI and OpenCode support.
+
+**New:**
+- `skills` field in `.claude-plugin/plugin.json` for explicit skill path declaration (Copilot CLI)
+
 ## orient 1.0.0
 
 Added orient plugin to the learning-opportunities marketplace.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,24 @@ Last verified: 2026-03-03
 
 ## What This Is
 
-A Claude Code plugin packaging science-based learning exercises for deliberate skill development during AI-assisted coding. Author: Dr. Cat Hicks. License: CC-BY-4.0.
+A plugin packaging science-based learning exercises for deliberate skill development during AI-assisted coding. Supports Claude Code, Codex, GitHub Copilot CLI, and OpenCode. Author: Dr. Cat Hicks. License: CC-BY-4.0.
 
 ## Project Structure
 
-- `.claude-plugin/marketplace.json` - Marketplace catalog (repo root is the marketplace)
+- `.claude-plugin/marketplace.json` - Marketplace catalog (Claude Code, Copilot CLI fallback)
+- `.github/plugin/marketplace.json` - Copilot CLI marketplace catalog (canonical location)
 - `.agents/plugins/marketplace.json` - Codex marketplace catalog
 - `learning-opportunities/` - The skill plugin
-  - `.claude-plugin/plugin.json` - Plugin manifest
+  - `.claude-plugin/plugin.json` - Plugin manifest (Claude Code / Copilot CLI)
   - `.codex-plugin/plugin.json` - Codex plugin manifest
   - `skills/learning-opportunities/` - The skill (SKILL.md + resources)
 - `learning-opportunities-auto/` - The auto-prompting hook plugin (requires `learning-opportunities`)
-  - `.claude-plugin/plugin.json` - Plugin manifest
+  - `.claude-plugin/plugin.json` - Plugin manifest (Claude Code / Copilot CLI)
   - `.codex-plugin/plugin.json` - Codex plugin manifest
-  - `hooks/post-tool-use.sh` - PostToolUse hook (bash)
+  - `hooks/post-tool-use.sh` - PostToolUse hook (bash, Claude Code / Codex / Copilot CLI)
+  - `.opencode/plugins/learning-opportunities-auto.ts` - OpenCode event plugin
 - `orient/` - The orientation generator plugin
-  - `.claude-plugin/plugin.json` - Plugin manifest
+  - `.claude-plugin/plugin.json` - Plugin manifest (Claude Code / Copilot CLI)
   - `.codex-plugin/plugin.json` - Codex plugin manifest
   - `skills/orient/` - The skill (SKILL.md)
 - `CHANGELOG.md` - Release history
@@ -31,7 +33,8 @@ Each plugin has its own version. When releasing, update the version in four plac
 1. `<plugin>/.claude-plugin/plugin.json` — bump `version`
 2. `<plugin>/.codex-plugin/plugin.json` — bump `version`
 3. `.claude-plugin/marketplace.json` — bump the matching plugin entry's `version`
-4. `CHANGELOG.md` — add entry at top, under the `# Changelog` heading
+4. `.github/plugin/marketplace.json` — bump the matching plugin entry's `version`
+5. `CHANGELOG.md` — add entry at top, under the `# Changelog` heading
 
 Use semver. All versioned files must show the same version string for the plugin being released. Commit them together.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Learning Opportunities: A Claude Code and Codex Skill for Deliberate Skill Development
+# Learning Opportunities: A Skill for Deliberate Skill Development
 
 **Build your expertise, not just your projects.**
 
@@ -10,6 +10,54 @@ Pairs well with [Learning-Goal](https://github.com/DrCatHicks/learning-goal), a 
 
 
 ## Installation
+
+### GitHub Copilot CLI
+
+This repository is a [Copilot CLI plugin marketplace](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace). To install:
+
+1. Add the marketplace:
+   ```
+   copilot 
+   /plugin marketplace add DrCatHicks/learning-opportunities
+   ```
+
+2. Install the plugin:
+   ```
+   copilot 
+   /plugin install learning-opportunities@learning-opportunities
+   ```
+
+The marketplace includes:
+
+- `learning-opportunities` — the core learning exercise skill
+- `learning-opportunities-auto` — optional post-commit prompting hook
+- `orient` — repo orientation generator
+
+### OpenCode
+
+OpenCode supports the skills in this repo directly. From your project directory, copy the skill and plugin files from a clone of this repo:
+
+**Skills (learning-opportunities, orient):**
+
+```bash
+# Project-level
+mkdir -p .opencode/skills
+cp -r /path/to/learning-opportunities/learning-opportunities/skills/learning-opportunities .opencode/skills/
+
+# Or personal (global)
+cp -r /path/to/learning-opportunities/learning-opportunities/skills/learning-opportunities ~/.agents/skills/
+```
+
+**Auto-prompting hook (learning-opportunities-auto):**
+
+> **Note:** This plugin requires the `learning-opportunities` skill (above) to be installed first. The hook nudges the agent to offer exercises, but the skill must be present for the agent to run them.
+
+```bash
+mkdir -p .opencode/plugins
+cp /path/to/learning-opportunities/learning-opportunities-auto/.opencode/plugins/learning-opportunities-auto.ts .opencode/plugins/
+```
+
+Then restart OpenCode. The plugin will detect git commits and nudge the agent to offer learning exercises.
 
 ### Codex
 
@@ -48,6 +96,15 @@ This repository is a [Claude Code plugin marketplace](https://docs.claude.com/en
 3. Restart Claude Code to activate
  
 For more on Claude Code plugins, see the [plugin documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+
+### GitHub Copilot CLI (alternate method)
+
+If you prefer to install directly from the repository without using the marketplace:
+
+```
+copilot 
+/plugin install DrCatHicks/learning-opportunities:learning-opportunities
+```
 
 ### Automatic Prompting (Optional)
 

--- a/learning-opportunities-auto/.claude-plugin/plugin.json
+++ b/learning-opportunities-auto/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities-auto",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Automatically nudges Claude to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
   "author": {
     "name": "Dr. Cat Hicks",
@@ -9,5 +9,6 @@
   "homepage": "https://github.com/DrCatHicks/learning-opportunities",
   "repository": "https://github.com/DrCatHicks/learning-opportunities",
   "license": "CC-BY-4.0",
-  "keywords": ["learning", "education", "skill-development", "expertise", "learning-science"]
+  "keywords": ["learning", "education", "skill-development", "expertise", "learning-science"],
+  "hooks": "hooks/hooks.json"
 }

--- a/learning-opportunities-auto/.codex-plugin/plugin.json
+++ b/learning-opportunities-auto/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities-auto",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Automatically nudges Codex to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
   "author": {
     "name": "Dr. Cat Hicks",

--- a/learning-opportunities-auto/.opencode/plugins/learning-opportunities-auto.ts
+++ b/learning-opportunities-auto/.opencode/plugins/learning-opportunities-auto.ts
@@ -1,0 +1,38 @@
+/**
+ * learning-opportunities-auto: OpenCode plugin
+ *
+ * Detects git commits after Bash tool executions and nudges the agent
+ * to offer a learning exercise via the learning-opportunities skill.
+ */
+
+const sessionOffers = new Map<string, number>()
+
+export const LearningOpportunitiesAuto = async ({ client }) => {
+  return {
+    "tool.execute.after": async (input, output) => {
+      // Only trigger on bash/shell tool executions
+      if (input.tool !== "bash") return
+
+      // Check if the command was a git commit
+      const command = output.args?.command || ""
+      if (!/git\s+commit/.test(command)) return
+
+      // Rate limit: max 2 offers per session
+      const sessionId = input.sessionId || "default"
+      const offers = sessionOffers.get(sessionId) || 0
+      if (offers >= 2) return
+
+      sessionOffers.set(sessionId, offers + 1)
+
+      // Inject learning nudge into the conversation context
+      output.metadata = output.metadata || {}
+      output.metadata.additionalContext =
+        "[learning-opportunities-auto] The user just committed code. " +
+        "Per the learning-opportunities skill, consider whether this is a good moment " +
+        "to offer a learning exercise. If the committed work involved new files, schema changes, " +
+        "architectural decisions, refactors, or unfamiliar patterns, ask the user (one short sentence) " +
+        "if they'd like a 10-15 minute exercise. Do not start the exercise until they confirm. " +
+        "If they decline, note it — no more offers this session."
+    },
+  }
+}

--- a/learning-opportunities/.claude-plugin/plugin.json
+++ b/learning-opportunities/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Science-based learning exercises for deliberate skill development during AI-assisted coding",
   "author": {
     "name": "Dr. Cat Hicks",
@@ -9,5 +9,6 @@
   "homepage": "https://github.com/DrCatHicks/learning-opportunities",
   "repository": "https://github.com/DrCatHicks/learning-opportunities",
   "license": "CC-BY-4.0",
-  "keywords": ["learning", "education", "skill-development", "expertise", "learning-science"]
+  "keywords": ["learning", "education", "skill-development", "expertise", "learning-science"],
+  "skills": "skills/"
 }

--- a/learning-opportunities/.codex-plugin/plugin.json
+++ b/learning-opportunities/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Science-based learning exercises for deliberate skill development during AI-assisted coding",
   "author": {
     "name": "Dr. Cat Hicks",

--- a/orient/.claude-plugin/plugin.json
+++ b/orient/.claude-plugin/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "orient",
   "description": "Generates a repo-specific orientation.md for use with the learning-opportunities skill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Dr. Michael Mullarkey"
   },
   "license": "CC-BY-4.0",
+  "skills": "skills/",
   "homepage": "https://mcmullarkey.github.io/",
   "repository": "https://github.com/DrCatHicks/learning-opportunities"
 }

--- a/orient/.codex-plugin/plugin.json
+++ b/orient/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orient",
   "description": "Generates a repo-specific orientation.md for use with the learning-opportunities skill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Dr. Michael Mullarkey"
   },


### PR DESCRIPTION
Adds support for OpenCode and GitHub Copilot CLI across all three plugins.

## Changes

### learning-opportunities 1.1.0
- Added `.github/plugin/marketplace.json` for canonical Copilot CLI marketplace discovery
- Added `skills` field in `.claude-plugin/plugin.json` for explicit skill path declaration (Copilot CLI)

### learning-opportunities-auto 1.1.0
- Added `.opencode/plugins/learning-opportunities-auto.ts` — OpenCode event plugin equivalent of the bash hook
- Added `hooks` field in `.claude-plugin/plugin.json` for explicit hook path declaration (Copilot CLI)

### orient 1.1.0
- Added `skills` field in `.claude-plugin/plugin.json` for explicit skill path declaration (Copilot CLI)

### Other
- Added `.github/plugin/marketplace.json` as canonical Copilot CLI marketplace catalog
- Updated CLAUDE.md, README.md, and CHANGELOG.md
- Bumped all plugin versions to 1.1.0