### PR TITLE
fix(auto): scope commit detection to the actual command + add jj support

### DIFF
--- a/learning-opportunities-auto/hooks/post-tool-use.sh
+++ b/learning-opportunities-auto/hooks/post-tool-use.sh
@@ -4,7 +4,8 @@ set -uo pipefail
 # learning-opportunities-auto: PostToolUse hook (matches Bash tool)
 #
 # Fires after every Bash tool use. Checks whether the command was a
-# `git commit` and, if so, suggests that Claude offer a learning exercise.
+# `git commit` or `jj commit` and, if so, suggests that Claude offer a
+# learning exercise.
 # The skill itself decides whether the commit's content is worth an
 # exercise — this hook just provides the nudge at the right moment.
 #
@@ -13,10 +14,11 @@ set -uo pipefail
 INPUT=$(cat)
 
 # ---------------------------------------------------------------------------
-# Check if this was a git commit. Claude Code sends shell text in a "command"
-# field; Codex can send it in a "cmd" field. We extract just that field's
-# value so we don't match against tool_response output that mentions
-# "git commit" (e.g. the user running `git log` or `grep "git commit" file`).
+# Check if this was a git or jj commit. Claude Code sends shell text in a
+# "command" field; Codex can send it in a "cmd" field. We extract just that
+# field's value so we don't match against tool_response output that mentions
+# "git commit" or "jj commit" (e.g. the user running `git log` or
+# `grep "jj commit" file`).
 # ---------------------------------------------------------------------------
 
 CMD=$(echo "$INPUT" | grep -oE '"(command|cmd)":"([^"\\]|\\.)*"' | head -1 | sed -E 's/^"(command|cmd)":"//; s/"$//')
@@ -32,14 +34,14 @@ fi
 #     separator (`;`, `&`, `|`, backtick, `(`) with optional whitespace, or
 #     after a `$(` command substitution. Prevents matching `foogit commit`.
 #
-#   git
-#     The literal `git`.
+#   (jj|git)
+#     The literal `jj` or `git`.
 #
 #   ([[:space:]]+-[^[:space:]"]+([[:space:]]+[^-[:space:]"][^[:space:]"]*)?)*
 #     Zero or more global-flag blocks. Each block is `<space>-<flag>`,
 #     optionally followed by `<space><value>` where the value doesn't start
-#     with `-`. This lets `git -C /repo commit` match, while keeping
-#     `git log -r commit` from matching (because `log` doesn't start with
+#     with `-`. This lets `jj -R /repo commit` match, while keeping
+#     `jj log -r commit` from matching (because `log` doesn't start with
 #     `-` so it isn't a flag).
 #
 #   [[:space:]]+commit
@@ -49,7 +51,7 @@ fi
 #     Terminator — whitespace, quote, shell separator, end of string, or
 #     backslash. Prevents matching things like `git commit-tree`.
 
-if ! echo "$CMD" | grep -Eq '(^|[;&|`(][[:space:]]*|\$\([[:space:]]*)git([[:space:]]+-[^[:space:]"]+([[:space:]]+[^-[:space:]"][^[:space:]"]*)?)*[[:space:]]+commit([[:space:]";|&)]|$|\\)'; then
+if ! echo "$CMD" | grep -Eq '(^|[;&|`(][[:space:]]*|\$\([[:space:]]*)(jj|git)([[:space:]]+-[^[:space:]"]+([[:space:]]+[^-[:space:]"][^[:space:]"]*)?)*[[:space:]]+commit([[:space:]";|&)]|$|\\)'; then
   exit 0
 fi
 

--- a/learning-opportunities-auto/hooks/post-tool-use.sh
+++ b/learning-opportunities-auto/hooks/post-tool-use.sh
@@ -14,12 +14,42 @@ INPUT=$(cat)
 
 # ---------------------------------------------------------------------------
 # Check if this was a git commit. Claude Code sends shell text in a "command"
-# field; Codex can send it in a "cmd" field. False positives (e.g., output
-# that mentions "git commit") are harmless — we just offer a learning exercise
-# unnecessarily.
+# field; Codex can send it in a "cmd" field. We extract just that field's
+# value so we don't match against tool_response output that mentions
+# "git commit" (e.g. the user running `git log` or `grep "git commit" file`).
 # ---------------------------------------------------------------------------
 
-if ! echo "$INPUT" | grep -Eq '"(command|cmd)".*git.*commit'; then
+CMD=$(echo "$INPUT" | grep -oE '"(command|cmd)":"([^"\\]|\\.)*"' | head -1 | sed -E 's/^"(command|cmd)":"//; s/"$//')
+
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# The regex below is gnarly, so here's the breakdown:
+#
+#   (^|[;&|`(][[:space:]]*|\$\([[:space:]]*)
+#     Anchor — match at the start of the command, or right after a shell
+#     separator (`;`, `&`, `|`, backtick, `(`) with optional whitespace, or
+#     after a `$(` command substitution. Prevents matching `foogit commit`.
+#
+#   git
+#     The literal `git`.
+#
+#   ([[:space:]]+-[^[:space:]"]+([[:space:]]+[^-[:space:]"][^[:space:]"]*)?)*
+#     Zero or more global-flag blocks. Each block is `<space>-<flag>`,
+#     optionally followed by `<space><value>` where the value doesn't start
+#     with `-`. This lets `git -C /repo commit` match, while keeping
+#     `git log -r commit` from matching (because `log` doesn't start with
+#     `-` so it isn't a flag).
+#
+#   [[:space:]]+commit
+#     The literal `commit` subcommand.
+#
+#   ([[:space:]";|&)]|$|\\)
+#     Terminator — whitespace, quote, shell separator, end of string, or
+#     backslash. Prevents matching things like `git commit-tree`.
+
+if ! echo "$CMD" | grep -Eq '(^|[;&|`(][[:space:]]*|\$\([[:space:]]*)git([[:space:]]+-[^[:space:]"]+([[:space:]]+[^-[:space:]"][^[:space:]"]*)?)*[[:space:]]+commit([[:space:]";|&)]|$|\\)'; then
   exit 0
 fi
 


### PR DESCRIPTION
Two independent commits — split so the bugfix can land on its own if you'd rather review or hold off on the jj addition.

## 1. `fix(auto): scope commit detection to the actual command field`

Pure bugfix. The current `git.*commit` regex matches against the entire hook input JSON, including `tool_response` — so any tool output that quoted a commit hash or contained the text "git commit" (e.g. `git log` output, file paths under `git_commit_history/`, the literal string inside a `grep` argument) tripped the learning nudge.

The new flow:

1. Extract `tool_input.command` (Claude Code) or `tool_input.cmd` (Codex) with a JSON-string-aware `grep`/`sed` pipeline — only the user's actual command, never the tool's output.
2. Anchor the regex: the command must begin with `git` (optionally after a shell separator `&&`, `||`, `;`, `|`, backtick, `(`, or `$(`), tolerate global flags + their values, then `commit` as a word with a shell-separator-aware terminator.

No new dependencies — pure `grep`/`sed`, works on both GNU and BSD coreutils. Existing top-of-file `"No external dependencies beyond bash and standard Unix tools."` still holds.

## 2. `feat(auto): add Jujutsu (jj) support`

Adds `jj` to the alternation. [Jujutsu](https://github.com/jj-vcs/jj) is a git-compatible VCS; in its default "colocated" mode `jj` operates directly on a standard `.git/` directory, so `jj commit -m "msg"` produces a real git commit. The learning-opportunities skill is fundamentally VCS-agnostic — the meaningful event is "the user finalized a chunk of work" — so jj invocations should trigger the same offer as git invocations.

Without this change, jj users never receive learning offers, despite doing exactly the same kind of work.

## Tested matrix

```
# Originally false-positive (bug the first commit fixes):
grep "git commit" file            # no match
ls git_commit_history             # no match
git log --oneline                 # no match
git-foo commit                    # no match
git commit-fixup                  # no match

# Standard git invocations:
git commit -m "msg"               # MATCH
git commit -m "msg" && push       # MATCH
git commit; echo done             # MATCH
(git commit)                      # MATCH
git commit | tee log              # MATCH
git -c foo.bar=baz commit         # MATCH (global flag tolerated)
cd foo && git commit              # MATCH (shell separator)
$(git commit)                     # MATCH (command substitution)

# jj invocations (added by second commit):
jj commit -m "msg"                # MATCH
jj commit; echo done              # MATCH
(jj commit)                       # MATCH
jj commit | tee log               # MATCH
jj -R /repo commit                # MATCH (global flag tolerated)
grep "jj commit" file             # no match
jj log -r commit                  # no match (commit is an arg)
jj describe -m "say commit"       # no match
```

The subcommand vs. argument distinction (`jj commit` vs. `jj log -r commit`): between `(jj|git)` and `commit`, every intermediate token must look like a flag (`-foo` / `--foo`) or a flag's value (a non-flag arg directly following a flag). `jj log -r commit` fails because `log` doesn't start with `-`.