### PR TITLE
fix: resolve Codex hook script from plugin cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "learning-opportunities-auto",
       "source": "./learning-opportunities-auto",
       "description": "Automatically nudges Claude to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Dr. Cat Hicks",
         "email": "dr.cat.hicks@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## learning-opportunities-auto 1.0.2
+
+**Fixed:**
+- Fixed Codex hook execution from repository working directories by resolving the hook script from Codex's plugin cache instead of using a repo-relative path
+
 ## orient 1.0.0
 
 Added orient plugin to the learning-opportunities marketplace.

--- a/learning-opportunities-auto/.claude-plugin/plugin.json
+++ b/learning-opportunities-auto/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities-auto",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Automatically nudges Claude to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
   "author": {
     "name": "Dr. Cat Hicks",

--- a/learning-opportunities-auto/.codex-plugin/plugin.json
+++ b/learning-opportunities-auto/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities-auto",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Automatically nudges Codex to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
   "author": {
     "name": "Dr. Cat Hicks",

--- a/learning-opportunities-auto/README.md
+++ b/learning-opportunities-auto/README.md
@@ -40,7 +40,7 @@ If you run into issues, check that `Git\bin` (not just `Git\cmd`) is on your PAT
 
 ## Codex Support
 
-Codex uses `hooks.codex.json`, which runs the same `hooks/post-tool-use.sh` script with a Codex-safe relative command. The script accepts both Claude Code's `command` payload field and Codex-style `cmd` payloads.
+Codex uses `hooks.codex.json`, which runs the same `hooks/post-tool-use.sh` script from Codex's plugin cache. The script accepts both Claude Code's `command` payload field and Codex-style `cmd` payloads.
 
 ## How Hooks Work
 

--- a/learning-opportunities-auto/hooks.codex.json
+++ b/learning-opportunities-auto/hooks.codex.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ./hooks/post-tool-use.sh"
+            "command": "bash -c 'script=\"${CODEX_HOME:-$HOME/.codex}/plugins/cache/learning-opportunities/learning-opportunities-auto/1.0.2/hooks/post-tool-use.sh\"; [ -f \"$script\" ] && exec bash \"$script\" || exit 0'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Fixes the Codex PostToolUse hook for `learning-opportunities-auto` so it resolves `post-tool-use.sh` from Codex's installed plugin cache instead of the current repository working directory. Bumps `learning-opportunities-auto` to 1.0.2 and updates the changelog/docs.

## Changes
- Change `hooks.codex.json` to execute the hook script from `${CODEX_HOME:-$HOME/.codex}/plugins/cache/...`
- Bump `learning-opportunities-auto` version metadata to 1.0.2
- Add changelog entry and update README Codex support wording

## Testing
- Reproduced the original failure before the patch with a fake Codex cache and arbitrary cwd: `bash: ./hooks/post-tool-use.sh: No such file or directory`
- Verified after the patch that the same scenario emits the expected `hookSpecificOutput` JSON
- Parsed all touched JSON manifests/configs with Ruby JSON
- Ran `git diff --check`
- Verified version consistency across both plugin manifests and the Claude marketplace entry

## Notes
`plugin-creator/scripts/validate_plugin.py` currently rejects the existing `.codex-plugin/plugin.json` `hooks` field, so it was not usable as a clean validation gate for this repository state.

## Breaking Changes
None