### PR TITLE
fix: detect actual git commit hook commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "learning-opportunities-auto",
       "source": "./learning-opportunities-auto",
       "description": "Automatically nudges Claude to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "Dr. Cat Hicks",
         "email": "dr.cat.hicks@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## learning-opportunities-auto 1.0.3
+
+**Fixed:**
+- Narrowed the Codex post-tool-use hook to read `cmd`/`command` only from the actual tool input, avoiding false positives from nested hook payload fields
+
 ## learning-opportunities-auto 1.0.2
 
 **Fixed:**

--- a/learning-opportunities-auto/.claude-plugin/plugin.json
+++ b/learning-opportunities-auto/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities-auto",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automatically nudges Claude to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
   "author": {
     "name": "Dr. Cat Hicks",

--- a/learning-opportunities-auto/.codex-plugin/plugin.json
+++ b/learning-opportunities-auto/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-opportunities-auto",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automatically nudges Codex to offer learning exercises after git commits. Requires the learning-opportunities plugin.",
   "author": {
     "name": "Dr. Cat Hicks",

--- a/learning-opportunities-auto/hooks.codex.json
+++ b/learning-opportunities-auto/hooks.codex.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'script=\"${CODEX_HOME:-$HOME/.codex}/plugins/cache/learning-opportunities/learning-opportunities-auto/1.0.2/hooks/post-tool-use.sh\"; [ -f \"$script\" ] && exec bash \"$script\" || exit 0'"
+            "command": "bash -c 'script=\"${CODEX_HOME:-$HOME/.codex}/plugins/cache/learning-opportunities/learning-opportunities-auto/1.0.3/hooks/post-tool-use.sh\"; [ -f \"$script\" ] && exec bash \"$script\" || exit 0'"
           }
         ]
       }

--- a/learning-opportunities-auto/hooks/post-tool-use.sh
+++ b/learning-opportunities-auto/hooks/post-tool-use.sh
@@ -6,31 +6,175 @@ set -uo pipefail
 # Fires after every Bash tool use. Checks whether the command was a
 # `git commit` and, if so, suggests that Claude offer a learning exercise.
 # The skill itself decides whether the commit's content is worth an
-# exercise — this hook just provides the nudge at the right moment.
+# exercise; this hook just provides the nudge at the right moment.
 #
 # No external dependencies beyond bash and standard Unix tools.
 
 INPUT=$(cat)
+JSON=$(printf '%s' "$INPUT" | tr '\n' ' ')
 
-# ---------------------------------------------------------------------------
-# Check if this was a git commit. Claude Code sends shell text in a "command"
-# field; Codex can send it in a "cmd" field. False positives (e.g., output
-# that mentions "git commit") are harmless — we just offer a learning exercise
-# unnecessarily.
-# ---------------------------------------------------------------------------
+# Claude Code sends shell text in tool_input.command; Codex sends it in
+# tool_input.cmd. Ignore command-like fields elsewhere in the payload so
+# tool_response output cannot trigger this hook.
+json_string() {
+  local key="$1"
+  local text="$2"
 
-if ! echo "$INPUT" | grep -Eq '"(command|cmd)".*git.*commit'; then
-  exit 0
+  printf '%s' "$text" |
+    sed -nE 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"(([^"\\]|\\.)*)".*/\1/p'
+}
+
+# Extract only a depth-1 object, so nested tool_response payloads are ignored.
+json_object() {
+  local key="$1"
+  local text="$2"
+  local -r JSON_CHARACTER_BYTES=1
+
+  printf '%s' "$text" |
+    LC_ALL=C fold -b -w "$JSON_CHARACTER_BYTES" |
+    LC_ALL=C awk -v key="$key" '
+      {
+        c = $0
+        if (capturing) {
+          if (in_string) {
+            printf "%s", c
+            if (escaped) escaped = 0
+            else if (c == "\\") escaped = 1
+            else if (c == "\"") in_string = 0
+            next
+          }
+
+          if (c == "\"") in_string = 1
+          else if (c == "{") capture_depth++
+          else if (c == "}") capture_depth--
+          if (capture_depth == 0) exit
+
+          printf "%s", c
+          next
+        }
+
+        if (in_string) {
+          if (escaped) {
+            escaped = 0
+            candidate = 0
+            next
+          }
+          if (c == "\\") {
+            escaped = 1
+            candidate = 0
+            next
+          }
+          if (c == "\"") {
+            in_string = 0
+            after_key = candidate && key_position > length(key)
+            next
+          }
+          if (!candidate) next
+
+          candidate = c == substr(key, key_position, 1)
+          key_position++
+          next
+        }
+
+        if (after_key && c ~ /[[:space:]]/) next
+        if (after_key && c == ":") {
+          after_key = 0
+          after_colon = 1
+          next
+        }
+        after_key = 0
+
+        if (after_colon && c ~ /[[:space:]]/) next
+        if (after_colon && c == "{") {
+          after_colon = 0
+          capturing = capture_depth = 1
+          next
+        }
+        after_colon = 0
+
+        if (c == "\"") {
+          in_string = 1
+          candidate = depth == 1
+          key_position = 1
+        } else if (c == "{") {
+          depth++
+        } else if (c == "}") {
+          depth--
+        }
+      }'
+}
+
+SESSION_ID=$(json_string session_id "$JSON")
+TOOL_INPUT=$(json_object tool_input "$JSON")
+COMMAND=$(json_string cmd "$TOOL_INPUT")
+if [[ -z "$COMMAND" ]]; then
+  COMMAND=$(json_string command "$TOOL_INPUT")
 fi
 
-# ---------------------------------------------------------------------------
-# Extract session_id for rate limiting. It's a top-level UUID — no escaped
-# quotes or nesting to worry about, so basic grep/sed is safe.
-# ---------------------------------------------------------------------------
+# Heuristic hook detector. Collapse quoted text to one argument before splitting,
+# so quoted command examples stay ignored without losing real argument positions.
+git_commit_segments() {
+  local -r QUOTED_ARGUMENT='__quoted_argument__'
+  local -r VALUE_OPTIONS='-m -F -C -c -t --message --file --reuse-message --reedit-message --fixup --squash --template --author --date --cleanup --trailer --pathspec-from-file'
+  local -r SHORT_VALUE_OPTIONS='mFCct'
+  local -r NON_MUTATING_OPTIONS='--help -h --dry-run'
 
-SESSION_ID=$(echo "$INPUT" | grep -o '"session_id":"[^"]*"' | head -1 | sed 's/"session_id":"//;s/"$//')
+  printf '%s\n' "$1" |
+    sed -E "s/'[^']*'/$QUOTED_ARGUMENT/g; s/\\\\?\"([^\"\\\\]|\\\\.)*\\\\?\"/$QUOTED_ARGUMENT/g" |
+    awk '{ gsub(/\\r\\n|\\n|\\r/, "\n"); print }' |
+    tr ';|&(){}' '\n' |
+    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' |
+    sed -nE '/^git([[:space:]]+-C[[:space:]]+[^[:space:]]+|[[:space:]]+-C[^[:space:]]+|[[:space:]]+-c[[:space:]]+[^[:space:]]+|[[:space:]]+-c[^[:space:]]+|[[:space:]]+--(no-pager|paginate|bare|literal-pathspecs|no-optional-locks|no-replace-objects))*[[:space:]]+commit([[:space:]]|$)/p' |
+    awk -v value_options="$VALUE_OPTIONS" -v short_value_options="$SHORT_VALUE_OPTIONS" \
+      -v non_mutating_options="$NON_MUTATING_OPTIONS" '
+      BEGIN {
+        split(value_options, values)
+        for (i in values) value_option[values[i]] = 1
 
-if [[ -z "$SESSION_ID" ]]; then
+        split(non_mutating_options, flags)
+        for (i in flags) non_mutating_option[flags[i]] = 1
+      }
+
+      {
+        for (i = 1; i <= NF && $i != "commit"; i++);
+
+        expects_value = 0
+        for (i++; i <= NF; i++) {
+          token = $i
+          if (expects_value) {
+            expects_value = 0
+            continue
+          }
+          if (token == "--") break
+          if (token in non_mutating_option) next
+
+          option = token
+          sub(/=.*/, "", option)
+          if (option in value_option && token == option) {
+            expects_value = 1
+            continue
+          }
+          if (token !~ /^-[^-]+$/) continue
+
+          short_options = token
+          sub(/^-/, "", short_options)
+          for (j = 1; j <= length(short_options); j++) {
+            short_option = substr(short_options, j, 1)
+            if (!index(short_value_options, short_option)) continue
+
+            expects_value = (j == length(short_options))
+            break
+          }
+        }
+
+        matched = 1
+        print
+      }
+
+      END { exit !matched }'
+}
+
+if [[ -z "$SESSION_ID" ]] || [[ -z "$COMMAND" ]] || ! git_commit_segments "$COMMAND" >/dev/null; then
   exit 0
 fi
 

--- a/learning-opportunities-auto/hooks/test-post-tool-use.sh
+++ b/learning-opportunities-auto/hooks/test-post-tool-use.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/post-tool-use.sh"
+TEST_TMP=$(mktemp -d)
+readonly LARGE_RESPONSE_BYTES=500000
+readonly MAX_HOOK_SECONDS=3
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+run_hook() {
+  local payload="$1"
+
+  TMPDIR="$TEST_TMP" bash "$HOOK" <<<"$payload"
+}
+
+assert_triggers() {
+  local name="$1"
+  local payload="$2"
+  local output
+  local status
+
+  set +e
+  output=$(run_hook "$payload")
+  status=$?
+  set -e
+
+  if (( status != 0 )); then
+    printf 'FAIL: %s hook exited with status %s\n' "$name" "$status" >&2
+    exit 1
+  fi
+  if [[ "$output" != *hookSpecificOutput* ]]; then
+    printf 'FAIL: %s should trigger\n' "$name" >&2
+    exit 1
+  fi
+}
+
+assert_ignores() {
+  local name="$1"
+  local payload="$2"
+  local max_seconds="${3:-0}"
+  local output
+  local status
+  local started_at=$SECONDS
+
+  set +e
+  output=$(run_hook "$payload")
+  status=$?
+  set -e
+
+  if (( max_seconds && SECONDS - started_at > max_seconds )); then
+    printf 'FAIL: %s took longer than %s seconds\n' "$name" "$max_seconds" >&2
+    exit 1
+  fi
+  if (( status != 0 )); then
+    printf 'FAIL: %s hook exited with status %s\n' "$name" "$status" >&2
+    exit 1
+  fi
+  if [[ -n "$output" ]]; then
+    printf 'FAIL: %s should be ignored, got: %s\n' "$name" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_triggers \
+  "basic git commit" \
+  '{"session_id":"trigger-basic","tool_input":{"cmd":"git commit -m test"},"tool_response":{}}'
+
+assert_triggers \
+  "git commit after cd" \
+  '{"session_id":"trigger-after-cd","tool_input":{"cmd":"cd repo && git commit -m test"},"tool_response":{}}'
+
+assert_triggers \
+  "git commit after escaped newline" \
+  '{"session_id":"trigger-after-escaped-newline","tool_input":{"cmd":"git add .\ngit commit -m test"},"tool_response":{}}'
+
+assert_triggers \
+  "git commit with global option" \
+  '{"session_id":"trigger-global-option","tool_input":{"cmd":"git -C repo commit --amend"},"tool_response":{}}'
+
+assert_triggers \
+  "git commit with quoted global option value" \
+  '{"session_id":"trigger-quoted-global-option","tool_input":{"cmd":"git -C \"$repo\" commit -m test"},"tool_response":{}}'
+
+assert_triggers \
+  "dry-run as commit message" \
+  '{"session_id":"trigger-dry-run-message","tool_input":{"cmd":"git commit -m --dry-run"},"tool_response":{}}'
+
+assert_triggers \
+  "help as combined short option value" \
+  '{"session_id":"trigger-help-message","tool_input":{"cmd":"git commit -am --help"},"tool_response":{}}'
+
+assert_triggers \
+  "claude command field" \
+  '{"session_id":"trigger-command-field","tool_input":{"command":"git commit -m test"},"tool_response":{}}'
+
+assert_triggers \
+  "pretty JSON session id" \
+  $'{\n  "session_id" : "trigger-pretty-json",\n  "tool_input" : { "cmd" : "git commit -m test" },\n  "tool_response" : {}\n}'
+
+assert_ignores \
+  "output mentions git commit" \
+  '{"session_id":"ignore-output","tool_input":{"cmd":"rg -n commit ."},"tool_response":{"stdout":"docs mention git commit here"}}'
+
+assert_ignores \
+  "nested response tool input after top-level tool input" \
+  '{"session_id":"ignore-nested-tool-input-after","tool_input":{"command":"git status --short"},"tool_response":{"tool_input":{"command":"git commit -m bogus"}}}'
+
+assert_ignores \
+  "searching for git commit" \
+  '{"session_id":"ignore-search","tool_input":{"cmd":"rg -n \"git commit\" ."},"tool_response":{}}'
+
+assert_ignores \
+  "echoing git commit" \
+  '{"session_id":"ignore-echo","tool_input":{"cmd":"echo git commit"},"tool_response":{}}'
+
+assert_ignores \
+  "quoted separator and git commit" \
+  '{"session_id":"ignore-quoted-separator","tool_input":{"cmd":"echo \"; git commit\""},"tool_response":{}}'
+
+assert_ignores \
+  "git status with commit in output" \
+  '{"session_id":"ignore-status","tool_input":{"cmd":"git status --short"},"tool_response":{"stdout":"nothing to commit, working tree clean"}}'
+
+assert_ignores \
+  "git log grep commit" \
+  '{"session_id":"ignore-log-grep","tool_input":{"cmd":"git log --grep commit"},"tool_response":{}}'
+
+assert_ignores \
+  "git commit help" \
+  '{"session_id":"ignore-commit-help","tool_input":{"cmd":"git commit --help"},"tool_response":{}}'
+
+assert_ignores \
+  "git commit dry run" \
+  '{"session_id":"ignore-commit-dry-run","tool_input":{"cmd":"git commit --dry-run"},"tool_response":{}}'
+
+assert_ignores \
+  "git commit dry run after message" \
+  '{"session_id":"ignore-commit-dry-run-after-message","tool_input":{"cmd":"git commit -m test --dry-run"},"tool_response":{}}'
+
+assert_ignores \
+  "git commit dry run after attached message" \
+  '{"session_id":"ignore-commit-dry-run-after-attached-message","tool_input":{"cmd":"git commit -mtest --dry-run"},"tool_response":{}}'
+
+assert_ignores \
+  "response command before tool input" \
+  '{"session_id":"ignore-response-command-first","tool_response":{"command":"git commit -m bogus"},"tool_input":{"command":"git status --short"}}'
+
+assert_ignores \
+  "nested command without tool input" \
+  '{"session_id":"ignore-nested-command-without-tool-input","tool_response":{"command":"git commit -m bogus"}}'
+
+assert_ignores \
+  "nested tool input before top-level tool input" \
+  '{"session_id":"ignore-nested-tool-input-first","tool_response":{"tool_input":{"command":"git commit -m bogus"}},"tool_input":{"command":"git status --short"}}'
+
+large_response=$(awk -v size="$LARGE_RESPONSE_BYTES" 'BEGIN { printf "%*s", size, "" }')
+assert_ignores \
+  "large response before tool input" \
+  '{"session_id":"ignore-large-response","tool_response":{"stdout":"'"$large_response"'"},"tool_input":{"command":"git status --short"}}' \
+  "$MAX_HOOK_SECONDS"
+
+assert_ignores \
+  "large shell command" \
+  '{"session_id":"ignore-large-command","tool_input":{"command":"git status '"$large_response"'"},"tool_response":{}}' \
+  "$MAX_HOOK_SECONDS"
+
+printf 'post-tool-use hook tests passed\n'


### PR DESCRIPTION
## Summary
Fixes the Codex/Claude PostToolUse hook for `learning-opportunities-auto` so it only nudges after an actual `git commit` shell command. This prevents ordinary tool calls from triggering the learning prompt when their output or search strings merely mention `git commit`.

## Changes
- Extract the hook payload's `cmd`/`command` field before checking for commit commands
- Replace the whole-payload grep with shell-token-aware detection for `git commit`, including command separators and common git global options
- Add regression coverage for real commit commands and false positives from search/output text
- Bump `learning-opportunities-auto` to 1.0.3 and update the Codex cache path, Claude marketplace metadata, and changelog

## Testing
- `bash -n learning-opportunities-auto/hooks/post-tool-use.sh learning-opportunities-auto/hooks/test-post-tool-use.sh`
- `learning-opportunities-auto/hooks/test-post-tool-use.sh`
- `git diff --check`
- Parsed touched JSON manifests/configs with Ruby JSON

## Notes
The hook still runs after each Bash/exec_command tool by design; this PR tightens the script-side filtering so non-commit tool calls exit silently.

(Yes, I had Codex write this. Looks fine to me though)

## Breaking Changes
None